### PR TITLE
feat(structs): expose struct fields for use by consumers of library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,57 +13,57 @@ pub enum PackageLockJsonError {
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, Eq, PartialEq)]
 pub struct PackageLockJson {
-    name: String,
-    version: String,
+    pub name: String,
+    pub version: String,
     #[serde(rename = "lockfileVersion")]
-    lockfile_version: u32,
-    dependencies: Option<HashMap<String, V1Dependency>>,
+    pub lockfile_version: u32,
+    pub dependencies: Option<HashMap<String, V1Dependency>>,
     #[serde(deserialize_with = "deserialize_packages", default)]
-    packages: Option<HashMap<String, V2Dependency>>,
+    pub packages: Option<HashMap<String, V2Dependency>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Default)]
 pub struct V1Dependency {
-    version: String,
-    resolved: String,
-    integrity: String,
+    pub version: String,
+    pub resolved: String,
+    pub integrity: String,
     #[serde(default)]
-    bundled: bool,
+    pub bundled: bool,
     #[serde(rename = "dev", default)]
-    is_dev: bool,
+    pub is_dev: bool,
     #[serde(rename = "optional", default)]
-    is_optional: bool,
-    requires: Option<HashMap<String, String>>,
-    dependencies: Option<HashMap<String, V1Dependency>>,
+    pub is_optional: bool,
+    pub requires: Option<HashMap<String, String>>,
+    pub dependencies: Option<HashMap<String, V1Dependency>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, Default)]
 pub struct V2Dependency {
-    version: String,
-    resolved: String,
-    integrity: String,
+    pub version: String,
+    pub resolved: String,
+    pub integrity: String,
     #[serde(default)]
-    bundled: bool,
+    pub bundled: bool,
     #[serde(rename = "dev", default)]
-    is_dev: bool,
+    pub is_dev: bool,
     #[serde(rename = "optional", default)]
-    is_optional: bool,
+    pub is_optional: bool,
     #[serde(rename = "devOptional", default)]
-    is_dev_optional: bool,
+    pub is_dev_optional: bool,
     #[serde(rename = "inBundle", default)]
-    is_in_bundle: bool,
+    pub is_in_bundle: bool,
     #[serde(rename = "hasInstallScript", default)]
-    has_install_script: bool,
+    pub has_install_script: bool,
     #[serde(rename = "hasShrinkwrap", default)]
-    has_shrink_wrap: bool,
-    dependencies: Option<HashMap<String, String>>,
+    pub has_shrink_wrap: bool,
+    pub dependencies: Option<HashMap<String, String>>,
     #[serde(rename = "optionalDependencies")]
-    optional_dependencies: Option<HashMap<String, String>>,
+    pub optional_dependencies: Option<HashMap<String, String>>,
     #[serde(rename = "peerDependencies")]
-    peer_dependencies: Option<HashMap<String, String>>,
-    license: Option<String>,
-    engines: Option<HashMap<String, String>>,
-    bin: Option<HashMap<String, String>>,
+    pub peer_dependencies: Option<HashMap<String, String>>,
+    pub license: Option<String>,
+    pub engines: Option<HashMap<String, String>>,
+    pub bin: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]


### PR DESCRIPTION
Firstly hi 👋 I was playing around with this crate and just wanted to make this PR to help me use the results the functions provided me. I didn't see any contribution guidelines so tried my best to remain consistent to your first commits. 

That being said feel free to discuss in the comments of this PR or even close it if you have other plans, I just thought presenting a PR was better than an issue.

### What this PR does

This adds `pub` to all the fields in the `PackageLockJson`, `V1Dependency` and `V2Dependency` structs - similar to the `SimpleDependency` struct. This allows users of this library to use the results from the `parse` function.